### PR TITLE
Task 85627

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.0]
+        php: [8.1]
         laravel: [8.*]
         stability: [prefer-lowest, prefer-stable]
         include:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,7 +18,7 @@ jobs:
         stability: [prefer-lowest, prefer-stable]
         include:
           - laravel: 8.*
-            testbench: ^6.6
+            testbench: ^6.23
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   ],
   "license": "MIT",
   "require": {
-    "php": "^8.0",
+    "php": "^8.1",
     "cebe/php-openapi": "^1.5"
   },
   "autoload": {
@@ -44,5 +44,11 @@
     "cs": "php-cs-fixer fix --config .php-cs-fixer.php",
     "test": "./vendor/bin/pest --no-coverage",
     "test-coverage": "vendor/bin/phpunit --coverage-html coverage"
+  },
+  "config": {
+    "allow-plugins": {
+      "pestphp/pest-plugin": true,
+      "composer/package-versions-deprecated": true
+    }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-   "name": "source",
+   "name": "laravel-openapi-server-generator",
    "lockfileVersion": 2,
    "requires": true,
    "packages": {

--- a/src/Generators/BaseGenerator.php
+++ b/src/Generators/BaseGenerator.php
@@ -2,6 +2,7 @@
 
 namespace Ensi\LaravelOpenApiServerGenerator\Generators;
 
+use Ensi\LaravelOpenApiServerGenerator\Utils\PhpDocGenerator;
 use Ensi\LaravelOpenApiServerGenerator\Utils\PSR4PathConverter;
 use Ensi\LaravelOpenApiServerGenerator\Utils\RouteHandlerParser;
 use Ensi\LaravelOpenApiServerGenerator\Utils\TemplatesManager;
@@ -19,6 +20,7 @@ class BaseGenerator
         protected PSR4PathConverter $psr4PathConverter,
         protected RouteHandlerParser $routeHandlerParser,
         protected TypesMapper $typesMapper,
+        protected PhpDocGenerator $phpDocGenerator,
     ) {
     }
 

--- a/src/Generators/EnumsGenerator.php
+++ b/src/Generators/EnumsGenerator.php
@@ -3,7 +3,6 @@
 namespace Ensi\LaravelOpenApiServerGenerator\Generators;
 
 use cebe\openapi\SpecObjectInterface;
-use Ensi\LaravelOpenApiServerGenerator\Utils\PhpDocGenerator;
 use InvalidArgumentException;
 use LogicException;
 use stdClass;
@@ -50,7 +49,7 @@ class EnumsGenerator extends BaseGenerator implements GeneratorInterface
 
     private function getEnumType(stdClass $schema, string $enumName): string
     {
-        return match($schema->type){
+        return match ($schema->type) {
             "integer" => "int",
             "string" => "string",
             default => throw new LogicException("Enum {$enumName} has invalid type '{$schema->type}'. Supported types are: ['integer', 'string']"),
@@ -78,8 +77,8 @@ class EnumsGenerator extends BaseGenerator implements GeneratorInterface
 
     private function convertEnumSchemaToPhpDoc(stdClass $schema): string
     {
-        return $schema->description 
-        ? "\n" . $this->phpDocGenerator->fromText(text: $schema->description, deleteEmptyLines: true) 
+        return $schema->description
+        ? "\n" . $this->phpDocGenerator->fromText(text: $schema->description, deleteEmptyLines: true)
         : "\n";
     }
 }

--- a/src/Generators/EnumsGenerator.php
+++ b/src/Generators/EnumsGenerator.php
@@ -3,6 +3,7 @@
 namespace Ensi\LaravelOpenApiServerGenerator\Generators;
 
 use cebe\openapi\SpecObjectInterface;
+use Ensi\LaravelOpenApiServerGenerator\Utils\PhpDocGenerator;
 use InvalidArgumentException;
 use LogicException;
 use stdClass;
@@ -25,16 +26,16 @@ class EnumsGenerator extends BaseGenerator implements GeneratorInterface
         $enums = $this->extractEnums($openApiData);
 
         $template = $this->templatesManager->getTemplate('Enum.template');
-        foreach ($enums as $className => $schema) {
-            $enumType = get_debug_type($schema->enum[0]);
+        foreach ($enums as $enumName => $schema) {
+            $enumType = $this->getEnumType($schema, $enumName);
             $this->filesystem->put(
-                rtrim($toDir, '/') . "/{$className}.php",
+                rtrim($toDir, '/') . "/{$enumName}.php",
                 $this->replacePlaceholders($template, [
                     '{{ namespace }}' => $namespace,
-                    '{{ className }}' => $className,
-                    '{{ constants }}' => $this->convertEnumSchemaToConstants($schema),
+                    '{{ enumName }}' => $enumName,
+                    '{{ cases }}' => $this->convertEnumSchemaToCases($schema),
                     '{{ enumType }}' => $enumType,
-                    '{{ valuesArray }}' => $this->convertEnumSchemaToValuesArray($schema),
+                    '{{ enumPhpDoc }}' => $this->convertEnumSchemaToPhpDoc($schema),
                 ])
             );
         }
@@ -47,7 +48,16 @@ class EnumsGenerator extends BaseGenerator implements GeneratorInterface
         return array_filter($schemas, fn ($schema) => !empty($schema->enum));
     }
 
-    private function convertEnumSchemaToConstants(stdClass $schema): string
+    private function getEnumType(stdClass $schema, string $enumName): string
+    {
+        return match($schema->type){
+            "integer" => "int",
+            "string" => "string",
+            default => throw new LogicException("Enum {$enumName} has invalid type '{$schema->type}'. Supported types are: ['integer', 'string']"),
+        };
+    }
+
+    private function convertEnumSchemaToCases(stdClass $schema): string
     {
         $result = '';
         foreach ($schema->enum as $i => $enum) {
@@ -55,21 +65,21 @@ class EnumsGenerator extends BaseGenerator implements GeneratorInterface
             if ($varName === null) {
                 throw new LogicException("x-enum-varnames for enum \"{$enum}\" is not set");
             }
+            $description = $schema->{'x-enum-descriptions'}[$i] ?? null;
+            if ($description) {
+                $result .= "    /** {$description} */\n";
+            }
             $value = var_export($enum, true);
-            $result .= "    public const {$varName} = {$value};\n";
+            $result .= "    case {$varName} = {$value};\n";
         }
 
-        return $result;
+        return rtrim($result, "\n");
     }
 
-    private function convertEnumSchemaToValuesArray(stdClass $schema): string
+    private function convertEnumSchemaToPhpDoc(stdClass $schema): string
     {
-        $result = "[\n";
-        foreach ($schema->{'x-enum-varnames'} as $varName) {
-            $result .= "            self::{$varName},\n";
-        }
-        $result .= '        ]';
-
-        return $result;
+        return $schema->description 
+        ? "\n" . $this->phpDocGenerator->fromText(text: $schema->description, deleteEmptyLines: true) 
+        : "\n";
     }
 }

--- a/src/Utils/PhpDocGenerator.php
+++ b/src/Utils/PhpDocGenerator.php
@@ -6,9 +6,10 @@ class PhpDocGenerator
 {
     public function fromText(string $text, int $spaces = 0, bool $deleteEmptyLines = false): string
     {
-        $result = $this->prependSpaces("/**\n", $spaces);
+        $eol = PHP_EOL;
+        $result = $this->prependSpaces("/**{$eol}", $spaces);
         foreach ($this->convertTextToLines($text, $deleteEmptyLines) as $line) {
-            $result .= $this->prependSpaces(" * {$this->safeLine($line)}\n", $spaces);
+            $result .= $this->prependSpaces(" * {$this->safeLine($line)}{$eol}", $spaces);
         }
         $result .= $this->prependSpaces(" */", $spaces);
 

--- a/src/Utils/PhpDocGenerator.php
+++ b/src/Utils/PhpDocGenerator.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Ensi\LaravelOpenApiServerGenerator\Utils;
+
+class PhpDocGenerator
+{
+    public function fromText(string $text, int $spaces = 0, bool $deleteEmptyLines = false): string
+    {
+        $result = $this->prependSpaces("/**\n", $spaces);
+        foreach ($this->convertTextToLines($text, $deleteEmptyLines) as $line) {
+            $result .= $this->prependSpaces(" * {$this->safeLine($line)}\n", $spaces);
+        }
+        $result .= $this->prependSpaces(" */", $spaces);
+
+        return $result;
+    }
+
+    private function prependSpaces(string $result, int $spaces = 0): string
+    {
+        return str_repeat(' ', $spaces) . $result;
+    }
+
+    private function safeLine(string $line): string
+    {
+        return str_replace('*/', '', $line);
+    }
+
+    private function convertTextToLines(string $text, bool $deleteEmptyLines): array
+    {
+        $lines = explode("\n", $text);
+        $trimmedLines = array_map(fn ($line) => trim($line), $lines);
+
+        return $deleteEmptyLines ? array_filter($trimmedLines) : $trimmedLines;
+    }
+}

--- a/templates/Enum.template
+++ b/templates/Enum.template
@@ -6,15 +6,8 @@
  */
 
 namespace {{ namespace }};
-
-class {{ className }}
+{{ enumPhpDoc }}
+enum {{ enumName }}: {{ enumType }}
 {
-{{ constants }}
-    /**
-     * @return {{ enumType }}[]
-     */
-    public static function cases(): array
-    {
-        return {{ valuesArray }};
-    }
+{{ cases }}
 }

--- a/tests/PhpDocGeneratorTest.php
+++ b/tests/PhpDocGeneratorTest.php
@@ -1,0 +1,92 @@
+<?php
+
+use Ensi\LaravelOpenApiServerGenerator\Utils\PhpDocGenerator;
+
+it('can generate phpdoc from single line string', function () {
+    $generator = new PhpDocGenerator();
+    $result = $generator->fromText("some text");
+
+    $expected = <<<"EOD"
+/**
+ * some text
+ */
+EOD;
+    expect($result)->toEqual($expected);
+});
+
+it('can generate phpdoc from with prepending spaces', function () {
+    $generator = new PhpDocGenerator();
+    $result = $generator->fromText("some text", 4);
+
+    $expected = <<<"EOD"
+    /**
+     * some text
+     */
+EOD;
+    expect($result)->toEqual($expected);
+});
+
+it('can generate phpdoc from multiline string', function () {
+    $generator = new PhpDocGenerator();
+    $multilineString = <<<'EOT'
+This is a test comment
+It is also multiline
+Wow
+EOT;
+    $result = $generator->fromText($multilineString, 4);
+
+    $expected = <<<"EOD"
+    /**
+     * This is a test comment
+     * It is also multiline
+     * Wow
+     */
+EOD;
+    expect($result)->toEqual($expected);
+});
+
+it('erases phpdoc end', function () {
+    $generator = new PhpDocGenerator();
+    $result = $generator->fromText("broken */text");
+
+    $expected = <<<"EOD"
+/**
+ * broken text
+ */
+EOD;
+    expect($result)->toEqual($expected);
+});
+
+it('trims lines', function () {
+    $generator = new PhpDocGenerator();
+    $result = $generator->fromText("    some text    ");
+
+    $expected = <<<"EOD"
+/**
+ * some text
+ */
+EOD;
+    expect($result)->toEqual($expected);
+});
+
+it('deletes empty lines if configured', function () {
+    $generator = new PhpDocGenerator();
+    $multilineString = <<<'EOT'
+This is a test comment
+
+It is also multiline
+And with empty line
+Wow
+EOT;
+    $result = $generator->fromText($multilineString, deleteEmptyLines: true);
+
+    $expected = <<<"EOD"
+/**
+ * This is a test comment
+ * It is also multiline
+ * And with empty line
+ * Wow
+ */
+EOD;
+    expect($result)->toEqual($expected);
+});


### PR DESCRIPTION
Даны OAS
![image](https://user-images.githubusercontent.com/2826480/151805950-a12275dd-0bda-4ffa-98ad-7585c2334855.png)
![image](https://user-images.githubusercontent.com/2826480/151806022-ef01e1d9-3746-44aa-8c51-6685be1d11e2.png)


Было 1:
![Screenshot 2022-01-31 165026](https://user-images.githubusercontent.com/2826480/151805487-1ceb6050-fe83-4da4-8737-8985ae3f89ed.png)
Было 2:
![image](https://user-images.githubusercontent.com/2826480/151805630-a688cbc4-f684-46a0-a828-0151fa3054f4.png)

Стало 1:
![image](https://user-images.githubusercontent.com/2826480/151805732-13860836-76f5-46cd-bc4c-98eaadc93e34.png)
Стало 2:
![image](https://user-images.githubusercontent.com/2826480/151805815-07ff7160-1fab-4c86-8a93-32a07efd7d6d.png)

Некоторые нюансы:

SomeEnum::cases() возвращает теперь массив объектов а не int/string со значениями.
У Backed enum значение получается через `->value`
Например, получить массив всех именно значений как раньше нужно написать `array_column(SomeEnum::cases(), 'values');`

Но в целом для енумов Http слоя это нужно будет реже потому что в основном они нужны для валидации, а для валидации в Laravel есть специальное правило https://laravel.com/docs/8.x/validation#rule-enum