### PR TITLE
#100773 Global template parameters

### DIFF
--- a/config/openapi-server-generator.php
+++ b/config/openapi-server-generator.php
@@ -11,9 +11,15 @@ return [
      * You can use as many yaml/json openapi entrypoints as you want.
      * Key = openapi entrypoint file with path.
      * Value = list of entities and their generator params.
+     *
+     * All values from 'params' will be available inside any template.
+     * apiVersion = {{ apiVersion}} in template.
      */
     'api_docs_mappings' => [
         public_path('api-docs/v1/index.yaml') => [
+            'params' => [
+                'apiVersion' => 1,
+            ],
             'controllers' => [],
             'enums' => [
                 'namespace' => "App\\Http\\ApiV1\\OpenApiGenerated\\Enums\\",

--- a/src/Generators/BaseGenerator.php
+++ b/src/Generators/BaseGenerator.php
@@ -34,6 +34,7 @@ class BaseGenerator
 
     protected function replacePlaceholders(string $content, array $placeholders, bool $removeExcessLineBreaks = false): string
     {
+        $placeholders = array_merge($placeholders, $this->formattedGlobalParams());
         $content = str_replace(array_keys($placeholders), array_values($placeholders), $content);
 
         // Убираем двойные переносы строк
@@ -77,5 +78,15 @@ class BaseGenerator
 
         $this->filesystem->ensureDirectoryExists($toDir);
         $this->filesystem->cleanDirectory($toDir);
+    }
+
+    private function formattedGlobalParams(): array
+    {
+        $params = [];
+        foreach ($this->options['params'] ?? [] as $key => $value) {
+            $params["{{ $key }}"] = $value;
+        }
+
+        return $params;
     }
 }


### PR DESCRIPTION
Добавил глобальные переменные для серверного генератора, которые он передает в шаблон.

К примеру, заполняем в конфиге параметр apiVersion:
``` php
public_path('api-docs/v2/index.yaml') => [
            'params' => [
                'apiVersion' => 2,
            ],
            'controllers' => [],
```
И можем в любом из шаблонов использовать **{{ apiVersion }}**. Таким же образом можно подставлять нужные классы, и вообще любые значения.
``` php
<?php

use App\Http\ApiV1\Support\Tests\ApiV{{ apiVersion }}ComponentTestCase;

{{ imports }}

uses(ApiV{{ apiVersion }}ComponentTestCase::class);
{{ tests }}
``` 